### PR TITLE
Implement manager layer and analyzer layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+// TODO: Update the data structs such that there is only one list of rooms.This list
+will contain both rooms that were generated via the public and private. However, the 
+Public:Rooms:Available list will still exist for the server to use to match make strangers. This
+should simplify the database and manager layers significantly.
 # Tic-Tac-GO
 
 Tic-Tac-GO is a website with a GO backend and a Javascript frontend where people can play 

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -5,9 +5,40 @@ import "tic-tac-go/pkg/manager"
 type analyzer struct {
 }
 
-func (a *analyzer) ValidMove(prevGameState string, playerMove string) (bool, error) {
-	return false, nil
+func NewAnalyzer() manager.Analyzer {
+	return &analyzer{}
 }
+
+func (a *analyzer) ValidMove(prevGameState string, playerMove string) (bool, error) {
+	if len(prevGameState) != 9 || len(playerMove) != 9 || prevGameState == playerMove {
+		return false, nil
+	}
+
+	ones := 0
+	twos := 0
+
+	for i := 0; i < len(prevGameState); i++ {
+		if playerMove[i] == '1' {
+			ones++
+		} else if playerMove[i] == '2' {
+			twos++
+		}
+
+		if prevGameState[i] != playerMove[i] {
+			// Valid move: From '0' (empty) to '1' or '2' (player marker)
+			if prevGameState[i] == '1' && playerMove[i] == '2' || prevGameState[i] == '2' && playerMove[i] == '1' {
+				return false, nil // Invalid move
+			}
+		}
+	}
+
+	if twos > ones || ones > twos+1 {
+		return false, nil // Invalid move
+	}
+
+	return true, nil
+}
+
 func (a *analyzer) DetermineWinner(playerMove string, players []manager.Player) ([]manager.Player, error) {
 	return []manager.Player{}, nil
 }

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -1,6 +1,10 @@
 package analyzer
 
-import "tic-tac-go/pkg/manager"
+import (
+	"fmt"
+	"log"
+	"tic-tac-go/pkg/manager"
+)
 
 type analyzer struct {
 }
@@ -40,5 +44,122 @@ func (a *analyzer) ValidMove(prevGameState string, playerMove string) (bool, err
 }
 
 func (a *analyzer) DetermineWinner(playerMove string, players []manager.Player) ([]manager.Player, error) {
+	for i := 0; i < 9; i += 3 {
+		if playerMove[i:i+3] == "111" {
+			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
+			return players, nil
+		} else if playerMove[i:i+3] == "222" {
+			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
+			return players, nil
+		}
+	}
+	for i := 0; i < 3; i++ {
+		verticalLine := fmt.Sprintf("%c%c%c", playerMove[i], playerMove[i+3], playerMove[i+6])
+		log.Printf("VErtical: %s", verticalLine)
+
+		if verticalLine == "111" {
+			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
+			return players, nil
+		} else if verticalLine == "222" {
+			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
+			return players, nil
+		}
+	}
+	for i := 0; i <= 2; i += 2 {
+		diagonalLine := fmt.Sprintf("%c%c%c", playerMove[i], playerMove[4], playerMove[8-i])
+		log.Printf("%s", diagonalLine)
+		if diagonalLine == "111" {
+			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
+			return players, nil
+		} else if diagonalLine == "222" {
+			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
+			return players, nil
+		}
+	}
+	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	return players, nil
+
+	checkHorizontalLines(playerMove, players)
+	checkVerticalLines(playerMove, players)
+	checkDiagonalLines(playerMove, players)
+	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+
 	return []manager.Player{}, nil
 }
+
+func checkHorizontalLines(playerMove string, players []manager.Player) []manager.Player {
+	for i := 0; i < 9; i += 3 {
+		if playerMove[i:i+3] == "111" {
+			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
+			return players
+		} else if playerMove[i:i+3] == "222" {
+			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
+			return players
+		}
+	}
+	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	return players
+}
+
+func checkVerticalLines(playerMove string, players []manager.Player) []manager.Player {
+	for i := 0; i < 3; i++ {
+		verticalLine := fmt.Sprintf("%c%c%c", playerMove[i], playerMove[i+3], playerMove[i+6])
+		log.Printf("VErtical: %s", verticalLine)
+
+		if verticalLine == "111" {
+			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
+			return players
+		} else if verticalLine == "222" {
+			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
+			return players
+		}
+	}
+	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	return players
+}
+
+func checkDiagonalLines(playerMove string, players []manager.Player) []manager.Player {
+	for i := 0; i <= 2; i += 2 {
+		diagonalLine := fmt.Sprintf("%c%c%c", playerMove[i], playerMove[4], playerMove[i+6])
+		log.Printf("%s", diagonalLine)
+		if diagonalLine == "111" {
+			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
+			return players
+		} else if diagonalLine == "222" {
+			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
+			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
+			return players
+		}
+	}
+	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	return players
+}
+
+// func determinSegmentWinner(line string, playerMove string, players []manager.Player) []manager.Player {
+// 	if line == "111" {
+// 		players[0].Message = fmt.Sprintf("%s:Win", playerMove)
+// 		players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
+// 		return players
+// 	} else if line == "222" {
+// 		players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
+// 		players[1].Message = fmt.Sprintf("%s:Win", playerMove)
+// 		return players
+// 	}
+// 	return players
+// }

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -5,7 +5,7 @@ import "tic-tac-go/pkg/manager"
 type analyzer struct {
 }
 
-func (a *analyzer) ValidGameState(prevGameState string, playerMove string) (bool, error) {
+func (a *analyzer) ValidMove(prevGameState string, playerMove string) (bool, error) {
 	return false, nil
 }
 func (a *analyzer) DetermineWinner(playerMove string, players []manager.Player) ([]manager.Player, error) {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -2,7 +2,7 @@ package analyzer
 
 import (
 	"fmt"
-	"log"
+	"strings"
 	"tic-tac-go/pkg/manager"
 )
 
@@ -14,6 +14,7 @@ func NewAnalyzer() manager.Analyzer {
 }
 
 func (a *analyzer) ValidMove(prevGameState string, playerMove string) (bool, error) {
+	// TODO: If the length is not 9 there should be an error.
 	if len(prevGameState) != 9 || len(playerMove) != 9 || prevGameState == playerMove {
 		return false, nil
 	}
@@ -44,122 +45,59 @@ func (a *analyzer) ValidMove(prevGameState string, playerMove string) (bool, err
 }
 
 func (a *analyzer) DetermineWinner(playerMove string, players []manager.Player) ([]manager.Player, error) {
+	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
+
+	if rowsContainAWinner(playerMove, &players) || columnsContainAWinner(playerMove, &players) ||
+		diagonalsContainAWinner(playerMove, &players) {
+		return players, nil
+	} else if !strings.Contains(playerMove, "0") {
+		players[0].Message = fmt.Sprintf("%s:Tie", playerMove)
+		players[1].Message = fmt.Sprintf("%s:Tie", playerMove)
+		return players, nil
+	}
+
+	return players, nil
+}
+
+func rowsContainAWinner(playerMove string, players *[]manager.Player) bool {
 	for i := 0; i < 9; i += 3 {
-		if playerMove[i:i+3] == "111" {
-			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
-			return players, nil
-		} else if playerMove[i:i+3] == "222" {
-			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
-			return players, nil
+		if isAWinningSegment(playerMove[i:i+3], playerMove, players) {
+			return true
 		}
 	}
+	return false
+}
+
+func columnsContainAWinner(playerMove string, players *[]manager.Player) bool {
 	for i := 0; i < 3; i++ {
 		verticalLine := fmt.Sprintf("%c%c%c", playerMove[i], playerMove[i+3], playerMove[i+6])
-		log.Printf("VErtical: %s", verticalLine)
-
-		if verticalLine == "111" {
-			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
-			return players, nil
-		} else if verticalLine == "222" {
-			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
-			return players, nil
+		if isAWinningSegment(verticalLine, playerMove, players) {
+			return true
 		}
 	}
+	return false
+}
+
+func diagonalsContainAWinner(playerMove string, players *[]manager.Player) bool {
 	for i := 0; i <= 2; i += 2 {
 		diagonalLine := fmt.Sprintf("%c%c%c", playerMove[i], playerMove[4], playerMove[8-i])
-		log.Printf("%s", diagonalLine)
-		if diagonalLine == "111" {
-			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
-			return players, nil
-		} else if diagonalLine == "222" {
-			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
-			return players, nil
+		if isAWinningSegment(diagonalLine, playerMove, players) {
+			return true
 		}
 	}
-	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-	return players, nil
-
-	checkHorizontalLines(playerMove, players)
-	checkVerticalLines(playerMove, players)
-	checkDiagonalLines(playerMove, players)
-	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-
-	return []manager.Player{}, nil
+	return false
 }
 
-func checkHorizontalLines(playerMove string, players []manager.Player) []manager.Player {
-	for i := 0; i < 9; i += 3 {
-		if playerMove[i:i+3] == "111" {
-			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
-			return players
-		} else if playerMove[i:i+3] == "222" {
-			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
-			return players
-		}
+func isAWinningSegment(line string, playerMove string, players *[]manager.Player) bool {
+	if line == "111" {
+		(*players)[0].Message = fmt.Sprintf("%s:Win", playerMove)
+		(*players)[1].Message = fmt.Sprintf("%s:Lose", playerMove)
+		return true
+	} else if line == "222" {
+		(*players)[0].Message = fmt.Sprintf("%s:Lose", playerMove)
+		(*players)[1].Message = fmt.Sprintf("%s:Win", playerMove)
+		return true
 	}
-	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-	return players
+	return false
 }
-
-func checkVerticalLines(playerMove string, players []manager.Player) []manager.Player {
-	for i := 0; i < 3; i++ {
-		verticalLine := fmt.Sprintf("%c%c%c", playerMove[i], playerMove[i+3], playerMove[i+6])
-		log.Printf("VErtical: %s", verticalLine)
-
-		if verticalLine == "111" {
-			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
-			return players
-		} else if verticalLine == "222" {
-			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
-			return players
-		}
-	}
-	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-	return players
-}
-
-func checkDiagonalLines(playerMove string, players []manager.Player) []manager.Player {
-	for i := 0; i <= 2; i += 2 {
-		diagonalLine := fmt.Sprintf("%c%c%c", playerMove[i], playerMove[4], playerMove[i+6])
-		log.Printf("%s", diagonalLine)
-		if diagonalLine == "111" {
-			players[0].Message = fmt.Sprintf("%s:Win", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
-			return players
-		} else if diagonalLine == "222" {
-			players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
-			players[1].Message = fmt.Sprintf("%s:Win", playerMove)
-			return players
-		}
-	}
-	players[0].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-	players[1].Message = fmt.Sprintf("%s:Ongoing", playerMove)
-	return players
-}
-
-// func determinSegmentWinner(line string, playerMove string, players []manager.Player) []manager.Player {
-// 	if line == "111" {
-// 		players[0].Message = fmt.Sprintf("%s:Win", playerMove)
-// 		players[1].Message = fmt.Sprintf("%s:Lose", playerMove)
-// 		return players
-// 	} else if line == "222" {
-// 		players[0].Message = fmt.Sprintf("%s:Lose", playerMove)
-// 		players[1].Message = fmt.Sprintf("%s:Win", playerMove)
-// 		return players
-// 	}
-// 	return players
-// }

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -1,0 +1,13 @@
+package analyzer
+
+import "tic-tac-go/pkg/manager"
+
+type analyzer struct {
+}
+
+func (a *analyzer) ValidGameState(prevGameState string, playerMove string) (bool, error) {
+	return false, nil
+}
+func (a *analyzer) DetermineWinner(playerMove string, players []manager.Player) ([]manager.Player, error) {
+	return []manager.Player{}, nil
+}

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,0 +1,61 @@
+package analyzer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidMoves(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		prevGameState string
+		playerMove    string
+	}{
+		{"000000000", "000010000"},
+		{"022110000", "022111000"},
+		{"220110001", "222110001"},
+	} {
+		tc := tc
+		t.Run(fmt.Sprintf("%s -> %s", tc.prevGameState, tc.playerMove), func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			analyzer := NewAnalyzer()
+			validMove, err := analyzer.ValidMove(tc.prevGameState, tc.playerMove)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.True(t, validMove)
+		})
+	}
+}
+
+func TestInValidMoves(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		prevGameState string
+		playerMove    string
+	}{
+		{"000000000", "000000000"}, // No change
+		{"000000000", "000020000"}, // Starting with 2
+		// {"000020000", "000120000"}, I would like this condition to result in a fail but it will never happen so I won't implement it.
+		{"000010000", "000110000"}, // Too many ones
+		{"000210000", "000212000"}, // Too many twos
+		{"000010000", "000020000"}, // Overwrite
+	} {
+		tc := tc
+		t.Run(fmt.Sprintf("%s -> %s", tc.prevGameState, tc.playerMove), func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			analyzer := NewAnalyzer()
+			validMove, err := analyzer.ValidMove(tc.prevGameState, tc.playerMove)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.False(t, validMove)
+		})
+	}
+}

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -3,10 +3,13 @@ package analyzer
 import (
 	"fmt"
 	"testing"
+	"tic-tac-go/pkg/manager"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
+// TODO: None of these need to return an error.
 func TestValidMoves(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -56,6 +59,55 @@ func TestInValidMoves(t *testing.T) {
 			// Assert
 			assert.NoError(t, err)
 			assert.False(t, validMove)
+		})
+	}
+}
+
+// TODO: Rename playerMove to gamestate for more clarity.
+// TODO: DetermineWinner seems overloaded, perhaps moving the append logic into manager will simplify it.
+func TestDeterminesWinner(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		playerMove    string
+		player1Result string
+		player2Result string
+	}{
+		{"000000000", "000000000:Ongoing", "000000000:Ongoing"}, // No change
+		{"111220000", "111220000:Win", "111220000:Lose"},        // P1 wins first row
+		{"222110100", "222110100:Lose", "222110100:Win"},        // P2 wins first row
+		{"220111000", "220111000:Win", "220111000:Lose"},        // P1 wins second row
+		{"110222100", "110222100:Lose", "110222100:Win"},        // P2 wins second row
+		{"200022111", "200022111:Win", "200022111:Lose"},        // P1 wins third row
+		{"100011222", "100011222:Lose", "100011222:Win"},        // P2 wins third row
+		{"122100100", "122100100:Win", "122100100:Lose"},        // P1 wins first column
+		{"211210200", "211210200:Lose", "211210200:Win"},        // P2 wins first column
+		{"210210010", "210210010:Win", "210210010:Lose"},        // P1 wins second column
+		{"121120020", "121120020:Lose", "121120020:Win"},        // P2 wins second column
+		{"001001221", "001001221:Win", "001001221:Lose"},        // P1 wins third column
+		{"002012112", "002012112:Lose", "002012112:Win"},        // P2 wins third column
+		{"120210001", "120210001:Win", "120210001:Lose"},        // P1 wins left to right diagonal
+		{"211120002", "211120002:Lose", "211120002:Win"},        // P2 wins left to right diagonal
+		{"201210100", "201210100:Win", "201210100:Lose"},        // P1 wins right to left diagonal
+		{"102021210", "102021210:Lose", "102021210:Win"},        // P2 wins right to left diagonal
+		{"221112211", "221112211:Tie", "221112211:Tie"},         // P2 wins right to left diagonal
+	} {
+		tc := tc
+		t.Run(fmt.Sprintf("game state %s", tc.playerMove), func(t *testing.T) {
+			t.Parallel()
+
+			player1ID := uuid.NewString()
+			player2ID := uuid.NewString()
+
+			players := []manager.Player{{ID: player1ID, Message: ""}, {ID: player2ID, Message: ""}}
+			expectedPlayers := []manager.Player{{ID: player1ID, Message: tc.player1Result}, {ID: player2ID, Message: tc.player2Result}}
+
+			// Act
+			analyzer := NewAnalyzer()
+			actualPlayers, err := analyzer.DetermineWinner(tc.playerMove, players)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, expectedPlayers, actualPlayers)
 		})
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,9 +19,7 @@ func NewConfig(env []string) *config {
 }
 
 func (c config) GetListeningPort() (int, error) {
-
 	env := c.env["LISTENING_PORT"]
 	port, _ := strconv.Atoi(env)
-
 	return port, nil
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1,0 +1,10 @@
+package database
+
+import "tic-tac-go/pkg/manager"
+
+type database struct {
+}
+
+func NewDatabase() manager.Database {
+	return &database{}
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -8,3 +8,11 @@ type database struct {
 func NewDatabase() manager.Database {
 	return &database{}
 }
+
+func (d *database) PublicRoomAvailable() bool {
+	return false
+}
+
+func (d *database) CreatePublicRoom(roomID string, playerID string) error {
+	return nil
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -21,8 +21,8 @@ func (d *database) JoinPublicRoom(playerID string) (string, string, error) {
 	return "", "", nil
 }
 
-func (d *database) RetrieveGameState(roomID string) (string, error) {
-	return "", nil
+func (d *database) RetrieveGame(roomID string) (manager.GameRoom, error) {
+	return manager.GameRoom{}, nil
 }
 
 func (d *database) ExecutePlayerMove(GameRoom string, roomID string) error {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -28,3 +28,7 @@ func (d *database) RetrieveGame(roomID string) (manager.GameRoom, error) {
 func (d *database) ExecutePlayerMove(GameRoom string, roomID string) error {
 	return nil
 }
+
+func (d *database) DeleteGameRoom(roomID string) error {
+	return nil
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -9,10 +9,22 @@ func NewDatabase() manager.Database {
 	return &database{}
 }
 
-func (d *database) PublicRoomAvailable() bool {
-	return false
+func (d *database) PublicRoomAvailable() (bool, error) {
+	return false, nil
 }
 
 func (d *database) CreatePublicRoom(roomID string, playerID string) error {
+	return nil
+}
+
+func (d *database) JoinPublicRoom(playerID string) (string, string, error) {
+	return "", "", nil
+}
+
+func (d *database) RetrieveGameState(roomID string) (string, error) {
+	return "", nil
+}
+
+func (d *database) ExecutePlayerMove(GameRoom string, roomID string) error {
 	return nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,6 +1,12 @@
 package manager
 
+import (
+	"github.com/google/uuid"
+)
+
 type Database interface {
+	PublicRoomAvailable() bool
+	CreatePublicRoom(roomID string, playerID string) error
 }
 
 type Manager interface {
@@ -18,6 +24,13 @@ func NewManager(database Database) Manager {
 }
 
 func (m *manager) StartGame(message string) (GameRoom, error) {
+	playerID := uuid.NewString()
+	if !m.database.PublicRoomAvailable() {
+		roomID := uuid.NewString()
+
+		_ = m.database.CreatePublicRoom(roomID, playerID)
+		return GameRoom{roomID, []Player{{playerID, "Waiting for Player"}}}, nil
+	}
 	return GameRoom{}, nil
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,11 +1,13 @@
 package manager
 
 import (
+	"log"
+
 	"github.com/google/uuid"
 )
 
 type Analyzer interface {
-	ValidGameState(prevGameState string, playerMove string) (bool, error)
+	ValidMove(prevGameState string, playerMove string) (bool, error)
 	DetermineWinner(playerMove string, players []Player) ([]Player, error)
 }
 
@@ -13,7 +15,7 @@ type Database interface {
 	PublicRoomAvailable() (bool, error)
 	CreatePublicRoom(roomID string, playerID string) error
 	JoinPublicRoom(playerID string) (string, string, error)
-	RetrieveGameState(roomID string) (string, error)
+	RetrieveGame(roomID string) (GameRoom, error)
 	ExecutePlayerMove(roomID string, playerMove string) error
 }
 
@@ -45,7 +47,21 @@ func (m *manager) StartGame(message string) (GameRoom, error) {
 	return GameRoom{roomID, []Player{{opponentID, "Start Game"}, {playerID, "Start Game"}}}, nil
 }
 
-func (m *manager) ExecutePlayerMove(roomID string, message string) (GameRoom, error) {
+// TODO: Consider having another object to store players and gamestate and exclude the message.
+// Perhaps call it a GameRoomState and rename the other to GameRoomMessenger.
+func (m *manager) ExecutePlayerMove(roomID string, playerMove string) (GameRoom, error) {
+	gameRoom, _ := m.database.RetrieveGame(roomID)
+	prevGameState := gameRoom.Players[0].Message
+	log.Printf("sasdfjas;klfjwepi\n\n %s", prevGameState)
+	log.Printf("ALFJASLFasdfsadfdsfadsf %s", playerMove)
+
+	validMove, _ := m.analyzer.ValidMove(prevGameState, playerMove)
+
+	if validMove {
+		_ = m.database.ExecutePlayerMove(roomID, playerMove)
+		players, _ := m.analyzer.DetermineWinner(playerMove, gameRoom.Players)
+		return GameRoom{gameRoom.RoomID, players}, nil
+	}
 	return GameRoom{}, nil
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,8 +1,6 @@
 package manager
 
 import (
-	"log"
-
 	"github.com/google/uuid"
 )
 
@@ -17,12 +15,13 @@ type Database interface {
 	JoinPublicRoom(playerID string) (string, string, error)
 	RetrieveGame(roomID string) (GameRoom, error)
 	ExecutePlayerMove(roomID string, playerMove string) error
+	DeleteGameRoom(roomID string) error
 }
 
 type Manager interface {
 	StartGame(message string) (GameRoom, error)
 	ExecutePlayerMove(roomID string, message string) (GameRoom, error)
-	EndGame(roomID string) GameRoom
+	EndGame(roomID string) (GameRoom, error)
 }
 
 type manager struct {
@@ -52,8 +51,6 @@ func (m *manager) StartGame(message string) (GameRoom, error) {
 func (m *manager) ExecutePlayerMove(roomID string, playerMove string) (GameRoom, error) {
 	gameRoom, _ := m.database.RetrieveGame(roomID)
 	prevGameState := gameRoom.Players[0].Message
-	log.Printf("sasdfjas;klfjwepi\n\n %s", prevGameState)
-	log.Printf("ALFJASLFasdfsadfdsfadsf %s", playerMove)
 
 	validMove, _ := m.analyzer.ValidMove(prevGameState, playerMove)
 
@@ -65,8 +62,14 @@ func (m *manager) ExecutePlayerMove(roomID string, playerMove string) (GameRoom,
 	return GameRoom{}, nil
 }
 
-func (m *manager) EndGame(roomID string) GameRoom {
-	return GameRoom{}
+func (m *manager) EndGame(roomID string) (GameRoom, error) {
+	gameRoom, _ := m.database.RetrieveGame(roomID)
+	_ = m.database.DeleteGameRoom(roomID)
+
+	gameRoom.Players[0].Message = "Terminate Connection"
+	gameRoom.Players[1].Message = "Terminate Connection"
+
+	return gameRoom, nil
 }
 
 type GameRoom struct {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,5 +1,8 @@
 package manager
 
+type Database interface {
+}
+
 type Manager interface {
 	StartGame(message string) (GameRoom, error)
 	MakePlayerMove(roomID string, message string) (GameRoom, error)
@@ -7,10 +10,11 @@ type Manager interface {
 }
 
 type manager struct {
+	database Database
 }
 
-func NewManager() Manager {
-	return &manager{}
+func NewManager(database Database) Manager {
+	return &manager{database}
 }
 
 func (m *manager) StartGame(message string) (GameRoom, error) {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -4,37 +4,48 @@ import (
 	"github.com/google/uuid"
 )
 
+type Analyzer interface {
+	ValidGameState(prevGameState string, playerMove string) (bool, error)
+	DetermineWinner(playerMove string, players []Player) ([]Player, error)
+}
+
 type Database interface {
-	PublicRoomAvailable() bool
+	PublicRoomAvailable() (bool, error)
 	CreatePublicRoom(roomID string, playerID string) error
+	JoinPublicRoom(playerID string) (string, string, error)
+	RetrieveGameState(roomID string) (string, error)
+	ExecutePlayerMove(roomID string, playerMove string) error
 }
 
 type Manager interface {
 	StartGame(message string) (GameRoom, error)
-	MakePlayerMove(roomID string, message string) (GameRoom, error)
+	ExecutePlayerMove(roomID string, message string) (GameRoom, error)
 	EndGame(roomID string) GameRoom
 }
 
 type manager struct {
 	database Database
+	analyzer Analyzer
 }
 
-func NewManager(database Database) Manager {
-	return &manager{database}
+func NewManager(database Database, analyzer Analyzer) Manager {
+	return &manager{database, analyzer}
 }
 
 func (m *manager) StartGame(message string) (GameRoom, error) {
 	playerID := uuid.NewString()
-	if !m.database.PublicRoomAvailable() {
+	roomAvailable, _ := m.database.PublicRoomAvailable()
+	if !roomAvailable {
 		roomID := uuid.NewString()
 
 		_ = m.database.CreatePublicRoom(roomID, playerID)
 		return GameRoom{roomID, []Player{{playerID, "Waiting for Player"}}}, nil
 	}
-	return GameRoom{}, nil
+	roomID, opponentID, _ := m.database.JoinPublicRoom(playerID)
+	return GameRoom{roomID, []Player{{opponentID, "Start Game"}, {playerID, "Start Game"}}}, nil
 }
 
-func (m *manager) MakePlayerMove(roomID string, message string) (GameRoom, error) {
+func (m *manager) ExecutePlayerMove(roomID string, message string) (GameRoom, error) {
 	return GameRoom{}, nil
 }
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1,0 +1,19 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartGameWhenNoRoomsAvailable(t *testing.T) {
+	// Arrange
+
+	// Act
+	manager := NewManager(nil)
+	actualGameRoom, err := manager.StartGame("Join Room")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, GameRoom{}, actualGameRoom)
+}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -4,19 +4,22 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func TestStartGameWhenNoRoomsAvailable(t *testing.T) {
+func TestStartGameWhenNoPublicRoomsAreAvailable(t *testing.T) {
+	t.Parallel()
+
 	database := new(mockDatabase)
 
 	// Arrange
-	database.On("PublicRoomAvailable").Return(false).Once()
+	database.On("PublicRoomAvailable").Return(false, nil).Once()
 	database.On("CreatePublicRoom", mock.MatchedBy(matchUUID), mock.MatchedBy(matchUUID)).Return(nil)
 
 	// Act
-	manager := NewManager(database)
+	manager := NewManager(database, nil)
 	actualGameRoom, err := manager.StartGame("Join Room")
 
 	roomID := database.Calls[1].Arguments.String(0)
@@ -28,22 +31,172 @@ func TestStartGameWhenNoRoomsAvailable(t *testing.T) {
 	database.AssertExpectations(t)
 }
 
+func TestStartGameWhenAPublicRoomIsAvailable(t *testing.T) {
+	t.Parallel()
+
+	roomID := uuid.NewString()
+	player1ID := uuid.NewString()
+
+	database := new(mockDatabase)
+
+	// Arrange
+	database.On("PublicRoomAvailable").Return(true, nil).Once()
+	database.On("JoinPublicRoom", matcher(matchUUID)).Return(roomID, player1ID, nil).Once()
+
+	// Act
+	manager := NewManager(database, nil)
+	actualGameRoom, err := manager.StartGame("Join Room")
+
+	expectedGameRoom := GameRoom{roomID, []Player{
+		{player1ID, "Start Game"},
+		{database.Calls[1].Arguments.String(0), "Start Game"},
+	}}
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, expectedGameRoom, actualGameRoom)
+	database.AssertExpectations(t)
+}
+
+// func TestExecutesPlayerMove(t *testing.T) {
+// 	t.Parallel()
+// 	for _, tc := range []struct {
+// 		playerMove    string
+// 		prevGameState string
+// 		gameRoom      GameRoom
+// 	}{
+// 		{
+// 			"000010000", "000000000", GameRoom{uuid.NewString(), []Player{
+// 				{uuid.NewString(), "000010000:Ongoing"},
+// 				{uuid.NewString(), "000010000:Ongoing"},
+// 			}},
+// 		},
+// 		{
+// 			"022111000", "022110000", GameRoom{uuid.NewString(), []Player{
+// 				{uuid.NewString(), "022111000:Win"},
+// 				{uuid.NewString(), "022111000:Lose"},
+// 			}},
+// 		},
+// 		{
+// 			"222110001", "220110001", GameRoom{uuid.NewString(), []Player{
+// 				{uuid.NewString(), "222110001:Lose"},
+// 				{uuid.NewString(), "222110001:Win"},
+// 			}},
+// 		},
+// 	} {
+// 		tc := tc
+// 		t.Run(fmt.Sprintf("with port %s", tc.playerMove), func(t *testing.T) {
+// 			t.Parallel()
+
+// 			players := []Player{
+// 				{tc.gameRoom.Players[0].ID, tc.playerMove},
+// 				{tc.gameRoom.Players[1].ID, tc.playerMove},
+// 			}
+
+// 			database := new(mockDatabase)
+// 			analyzer := new(mockAnalyzer)
+
+// 			// Arrange
+// 			database.On("RetrieveGameState", matcher(matchUUID)).Return(tc.prevGameState, nil).Once()
+// 			analyzer.On("ValidGameState", tc.prevGameState, matcher(matchGameBoard)).Return(true, nil).Once()
+// 			database.On("ExecutePlayerMove", matcher(matchUUID), matcher(matchGameBoard)).Return(nil).Once()
+// 			analyzer.On("DetermineWinner", matcher(matchGameBoard), players).Return(tc.gameRoom.Players, nil).Once()
+
+// 			// Act
+// 			manager := NewManager(database, analyzer)
+// 			actualGameRoom, err := manager.ExecutePlayerMove(tc.gameRoom.RoomID, tc.playerMove)
+
+// 			// Assert
+// 			assert.NoError(t, err)
+// 			assert.Equal(t, tc.gameRoom, actualGameRoom)
+// 			mock.AssertExpectationsForObjects(t, database, analyzer)
+// 		})
+// 	}
+// }
+
+// func TestEndGame(t *testing.T) {
+// 	t.Parallel()
+
+// 	roomID := uuid.NewString()
+// 	player1ID := uuid.NewString()
+
+// 	database := new(mockDatabase)
+
+// 	// Arrange
+// 	database.On("PublicRoomAvailable").Return(true, nil).Once()
+// 	database.On("JoinPublicRoom", matcher(matchUUID)).Return(roomID, player1ID, nil).Once()
+
+// 	// Act
+// 	manager := NewManager(database)
+// 	actualGameRoom := manager.EndGame(roomID)
+
+// 	expectedGameRoom := GameRoom{roomID, []Player{
+// 		{player1ID, "Start Game"},
+// 		{database.Calls[1].Arguments.String(0), "Start Game"},
+// 	}}
+
+// 	// Assert
+// 	assert.NoError(t, err)
+// 	assert.Equal(t, expectedGameRoom, actualGameRoom)
+// 	database.AssertExpectations(t)
+// }
+
 type mockDatabase struct {
 	mock.Mock
 }
 
-func (m *mockDatabase) PublicRoomAvailable() bool {
+func (m *mockDatabase) PublicRoomAvailable() (bool, error) {
 	args := m.Called()
-
-	return args.Bool(0)
+	return args.Bool(0), args.Error(1)
 }
+
 func (m *mockDatabase) CreatePublicRoom(roomID string, playerID string) error {
 	args := m.Called(roomID, playerID)
 	return args.Error(0)
 }
 
+func (m *mockDatabase) JoinPublicRoom(playerID string) (string, string, error) {
+	args := m.Called(playerID)
+	return args.String(0), args.String(1), args.Error(2)
+}
+
+func (m *mockDatabase) RetrieveGameState(roomID string) (string, error) {
+	args := m.Called(roomID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockDatabase) ExecutePlayerMove(roomID string, playerMove string) error {
+	args := m.Called(roomID, playerMove)
+	return args.Error(0)
+}
+
+type mockAnalyzer struct {
+	mock.Mock
+}
+
+func (m *mockAnalyzer) ValidGameState(prevGameState string, playerMove string) (bool, error) {
+	args := m.Called(prevGameState, playerMove)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockAnalyzer) DetermineWinner(playerMove string, players []Player) ([]Player, error) {
+	args := m.Called(playerMove, players)
+	return args.Get(0).([]Player), args.Error(1)
+}
+
+func matcher(fn interface{}) interface{} {
+	return mock.MatchedBy(fn)
+}
+
 func matchUUID(uuid string) bool {
 	pattern := `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`
+	regex := regexp.MustCompile(pattern)
+
+	return regex.MatchString(uuid)
+}
+
+func matchGameBoard(uuid string) bool {
+	pattern := `"^[012]{9}$"`
 	regex := regexp.MustCompile(pattern)
 
 	return regex.MatchString(uuid)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1,19 +1,50 @@
 package manager
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestStartGameWhenNoRoomsAvailable(t *testing.T) {
+	database := new(mockDatabase)
+
 	// Arrange
+	database.On("PublicRoomAvailable").Return(false).Once()
+	database.On("CreatePublicRoom", mock.MatchedBy(matchUUID), mock.MatchedBy(matchUUID)).Return(nil)
 
 	// Act
-	manager := NewManager(nil)
+	manager := NewManager(database)
 	actualGameRoom, err := manager.StartGame("Join Room")
+
+	roomID := database.Calls[1].Arguments.String(0)
+	playerID := database.Calls[1].Arguments.String(1)
 
 	// Assert
 	assert.NoError(t, err)
-	assert.Equal(t, GameRoom{}, actualGameRoom)
+	assert.Equal(t, GameRoom{roomID, []Player{{playerID, "Waiting for Player"}}}, actualGameRoom)
+	database.AssertExpectations(t)
+}
+
+type mockDatabase struct {
+	mock.Mock
+}
+
+func (m *mockDatabase) PublicRoomAvailable() bool {
+	args := m.Called()
+
+	return args.Bool(0)
+}
+func (m *mockDatabase) CreatePublicRoom(roomID string, playerID string) error {
+	args := m.Called(roomID, playerID)
+	return args.Error(0)
+}
+
+func matchUUID(uuid string) bool {
+	pattern := `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`
+	regex := regexp.MustCompile(pattern)
+
+	return regex.MatchString(uuid)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,7 +48,7 @@ func NewHTTPServer(port int, manager manager.Manager) *HTTPServer {
 
 			switch {
 			case regex.MatchString(playerMessage):
-				game, _ := manager.MakePlayerMove(game.RoomID, playerMessage)
+				game, _ := manager.ExecutePlayerMove(game.RoomID, playerMessage)
 				sendMessageToClients(game)
 			case playerMessage == "End Game":
 				game := manager.EndGame(game.RoomID)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -51,7 +51,7 @@ func NewHTTPServer(port int, manager manager.Manager) *HTTPServer {
 				game, _ := manager.ExecutePlayerMove(game.RoomID, playerMessage)
 				sendMessageToClients(game)
 			case playerMessage == "End Game":
-				game := manager.EndGame(game.RoomID)
+				game, _ := manager.EndGame(game.RoomID)
 				sendMessageToClients(game)
 			}
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -122,7 +122,7 @@ func TestExpectedGameplayForPublicEndpoint(t *testing.T) {
 		}, nil,
 	).Once()
 
-	gameManager.On("MakePlayerMove", roomID, "022110000").Return(
+	gameManager.On("ExecutePlayerMove", roomID, "022110000").Return(
 		manager.GameRoom{
 			RoomID: roomID, Players: []manager.Player{
 				{ID: player1ID, Message: "022110000:Ongoing"},
@@ -131,7 +131,7 @@ func TestExpectedGameplayForPublicEndpoint(t *testing.T) {
 		}, nil,
 	).Once()
 
-	gameManager.On("MakePlayerMove", roomID, "022111000").Return(
+	gameManager.On("ExecutePlayerMove", roomID, "022111000").Return(
 		manager.GameRoom{
 			RoomID: roomID, Players: []manager.Player{
 				{ID: player1ID, Message: "022111000:Win"},
@@ -190,7 +190,7 @@ func (m *mockManager) StartGame(message string) (manager.GameRoom, error) {
 	return args.Get(0).(manager.GameRoom), args.Error(1)
 }
 
-func (m *mockManager) MakePlayerMove(roomID string, message string) (manager.GameRoom, error) {
+func (m *mockManager) ExecutePlayerMove(roomID string, message string) (manager.GameRoom, error) {
 	args := m.Called(roomID, message)
 	return args.Get(0).(manager.GameRoom), args.Error(1)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -195,7 +195,7 @@ func (m *mockManager) ExecutePlayerMove(roomID string, message string) (manager.
 	return args.Get(0).(manager.GameRoom), args.Error(1)
 }
 
-func (m *mockManager) EndGame(roomID string) manager.GameRoom {
+func (m *mockManager) EndGame(roomID string) (manager.GameRoom, error) {
 	args := m.Called(roomID)
-	return args.Get(0).(manager.GameRoom)
+	return args.Get(0).(manager.GameRoom), args.Error(1)
 }


### PR DESCRIPTION
This MR implements the manager and analyzer layer. There is a bunch of todo comments that I do not feel like handling just yet, not until error handling occurs lol. To summarize, the data structures that are being used rn is overloaded. It is used absolutely everywhere and tends to convolute things. This is due to its initial role to transfer messages however, lower layers are not concerned with the messages. It should just be the server and handler layer. Thus that responsibility will be shifted out of the analyzer layer and into the manager... hopefully.

Also, we do not need to lists of rooms, that over complicates things. Just one room should suffice, again, I will not be doing this in the current MR. Just leaving this here as a note.